### PR TITLE
修改v-list传递的url属性值

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,10 +9,10 @@
       </li>
     </ul>
     <v-list
-      url="https://raw.githubusercontent.com/996icu/996.ICU/master/blacklist/blacklist.md"
+      url="https://raw.githubusercontent.com/996icu/996.ICU/master/blacklist/README.md"
       v-show="select === '996'"></v-list>
     <v-list
-      url="https://raw.githubusercontent.com/996icu/996.ICU/master/whitelist/whitelist.md"
+      url="https://raw.githubusercontent.com/996icu/996.ICU/master/whitelist/README.md"
       v-show="select === '955'"></v-list>
   </div>
 </template>


### PR DESCRIPTION
996.ICU 修改了 blacklist 和 whitelist 里 md 文件名称为 README.md，对应修改了 v-list 组件需要的 url 属性值